### PR TITLE
Fix AWS SDK Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <!-- PROJECT METADATA -->
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-s3-rolling-policy</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <packaging>jar</packaging>
 
     <name>logback-s3-rolling-policy</name>
@@ -97,7 +97,7 @@
 
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-s3</artifactId>
             <version>${aws-java-sdk.version}</version>
         </dependency>
 


### PR DESCRIPTION
# 概要

AWS SDK の依存をすべて持ってきているため、これ自体がクソデカ依存になってしまっている。必要なものだけに変更する

# 修正内容

- fix: remove Unused AWS SDK Dependency
- feat: Increment Patch Version

Memo: ここで Version あげる Commit はおかしいか・・

# 確認

S3 に関連するライブラリのみの依存になっている

![スクリーンショット 2021-09-16 10 12 32](https://user-images.githubusercontent.com/2126669/133533903-ff805cb3-52ce-43a3-8854-20ac8682ef0a.jpg)
