### PR TITLE
Use the sts artifact of the AWS SDK to support advanced authentication methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>


### PR DESCRIPTION
Hi komuro.hiraku,
please consider this PR adding support for [AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html) allowing for advanced authentication.
This allows "magic" such as [a service account associated with an IAM role](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html) to work with no other code chages.

Thank you,
zeelax